### PR TITLE
compatibility: support kernel 6.4.10

### DIFF
--- a/src/compatibility.h
+++ b/src/compatibility.h
@@ -21,6 +21,14 @@
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,0) */
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,31) */
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,10)
+#if defined __has_include
+#if __has_include (<net/gso.h>)
+#include <net/gso.h>
+#endif
+#endif
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERISON(6,4,10) */
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,19,0)
 	#define TSO_LEGACY_MAX_SIZE		65536
 	#define netif_napi_add_weight		netif_napi_add


### PR DESCRIPTION
Include net/gso.h on kernel version 6.4.10 and newer as proposed in #12. 
The gso declarations were moved as part of an upstream patch set

d457a0e329b0 ("net: move gso declarations and functions to their own files")

This has been tested on a 6.5.1 mainline kernel with a Plugable ud-ca1a dock.