### PR TITLE
Minor fixes to build under 6.8.0-11-generic under Ubuntu 24.04

### DIFF
--- a/dkms-install.sh
+++ b/dkms-install.sh
@@ -14,8 +14,8 @@ DRV_VERSION=2.17.1
 cp -r ${DRV_DIR} /usr/src/${DRV_NAME}-${DRV_VERSION}
 
 dkms add -m ${DRV_NAME} -v ${DRV_VERSION}
-dkms build -m ${DRV_NAME} -v ${DRV_VERSION}
-dkms install -m ${DRV_NAME} -v ${DRV_VERSION}
+dkms build -m ${DRV_NAME} -v ${DRV_VERSION} --force
+dkms install -m ${DRV_NAME} -v ${DRV_VERSION} --force
 RESULT=$?
 
 echo "Finished running dkms install steps."

--- a/src/r8152.c
+++ b/src/r8152.c
@@ -19684,7 +19684,7 @@ static int rtltool_ioctl(struct r8152 *tp, struct ifreq *ifr)
 		uinfo->idVendor = __le16_to_cpu(udev->descriptor.idVendor);
 		uinfo->idProduct = __le16_to_cpu(udev->descriptor.idProduct);
 		uinfo->bcdDevice = __le16_to_cpu(udev->descriptor.bcdDevice);
-		strlcpy(uinfo->devpath, udev->devpath, sizeof(udev->devpath));
+		strscpy(uinfo->devpath, udev->devpath, sizeof(udev->devpath));
 		pla_ocp_read(tp, PLA_IDR, sizeof(uinfo->dev_addr),
 			     uinfo->dev_addr);
 


### PR DESCRIPTION
Just a couple of quick fixes to allow this to build cleanly under 6.8.0-11 for Ubuntu 24.04. 

For the future: 

* `RTLTOOL_USB_INFO` could be refactored to include some safety checks for `udev` and `udev->descriptor` so we don't accidentally NULL deref if they don't exist. 

* We could also add some additional error handling for `pla_ocp_read` and check that the size of `my_cmd.nic_info` is the right size to hold the `usb_device_info` structure to avoid a possible buffer overflow condition. 

I'll keep poking at it. 
