### PR TITLE
Add support for .ko.zst kernel modules, Dell Alienware AW1022 NIC, and fix udev rules handling

### DIFF
--- a/autorun.sh
+++ b/autorun.sh
@@ -11,8 +11,8 @@ fi
 echo
 check=`lsmod | grep r8152`
 if [ "$check" != "" ]; then
-        echo "rmmod r8152"
-        /sbin/rmmod r8152
+        echo "modprobe -r r8152"
+	/usr/sbin/modprobe -r r8152
 fi
 
 echo "Build the module and install"

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,8 +24,9 @@ else
 	PWD :=$(shell pwd)
 	TARGET_PATH := kernel/drivers/net/usb
 	INBOXDRIVER := $(shell find $(subst build,$(TARGET_PATH),$(KERNELDIR)) -name r8152.ko.* -type f)
-	RULEFILE = 50-usb-realtek-net.rules
-	RULEDIR = /etc/udev/rules.d/
+        MODFILE := /lib/modules/$(shell uname -r)/kernel/drivers/net/usb/r8152.ko
+	SRC_RULEFILE = ../udev/rules.d/50-usb-realtek-net.rules
+	TARGET_RULEDIR = /etc/udev/rules.d/
 
 .PHONY: modules
 modules:
@@ -41,20 +42,21 @@ clean:
 .PHONY: install
 install:
 ifneq ($(shell lsmod | grep r8153_ecm),)
-	rmmod r8153_ecm
+	modprobe -r r8153_ecm
 endif
 ifneq ($(shell lsmod | grep r8152),)
-	rmmod r8152
+	modprobe -r r8152
 endif
 ifneq ($(INBOXDRIVER),)
 	rm -f $(INBOXDRIVER)
 endif
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) INSTALL_MOD_DIR=$(TARGET_PATH) modules_install
+	zstd -19 -f $(MODFILE)
 	modprobe r8152
 
 .PHONY: install_rules
 install_rules:
-	install --group=root --owner=root --mode=0644 $(RULEFILE) $(RULEDIR)
+	install --group=root --owner=root --mode=0644 $(SRC_RULEFILE) -t $(TARGET_RULEDIR)
 
 endif
 

--- a/src/r8152.c
+++ b/src/r8152.c
@@ -835,6 +835,7 @@ enum rtl8152_flags {
 #define VENDOR_ID_LINKSYS		0x13b1
 #define VENDOR_ID_NVIDIA		0x0955
 #define VENDOR_ID_TPLINK		0x2357
+#define VENDOR_ID_DELL                  0x413c
 
 #define MCU_TYPE_PLA			0x0100
 #define MCU_TYPE_USB			0x0000
@@ -25688,6 +25689,9 @@ static const struct usb_device_id rtl8152_table[] = {
 
 	/* ASUSTek */
 	REALTEK_USB_DEVICE(0x0b05, 0x1976),
+
+	/* DELL */
+	REALTEK_USB_DEVICE(VENDOR_ID_DELL, 0xb097),
 
 	{}
 };


### PR DESCRIPTION
### Add support for .ko.zst kernel modules in newer Ubuntu versions
This update enhances the project to ensure compatibility with newer Ubuntu versions that use .ko.zst (Zstandard compressed) kernel modules. The logic has been updated to correctly handle .ko.zst files, which are now standard in Ubuntu versions 21.10 and later. This improves functionality on modern systems.

### Add support for Network interface Dell Alienware AW1022 2.5Gb USB NIC (device ID 413C:B097)
Dell Alienware AW1022 2.5Gb USB NIC Support: Added driver support for the Dell Alienware AW1022 2.5Gb USB Network Interface Card, enabling proper detection and functionality of this NIC on supported systems.

### Fixed udev rules handling ###
Resolved an issue where the script could not locate the udev rules file when switching to the src subdirectory, resulting in an error. The handling of the udev rules file has been corrected, and the necessary entry for the Dell Alienware AW1022 NIC has been added to the udev rules as well.

