### PR TITLE
Enable compiling for intended kernel versions

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -2,7 +2,7 @@ PACKAGE_NAME="realtek-r8152"
 PACKAGE_VERSION="2.19.2"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
-MAKE="'make' -j$PROCS_NUM modules"
+MAKE="'make' -j$PROCS_NUM modules KERNELDIR=/lib/modules/${kernelver}/build"
 CLEAN="'make' clean"
 BUILT_MODULE_NAME[0]="r8152"
 BUILT_MODULE_LOCATION[0]="src"


### PR DESCRIPTION
This is actually an important fix. Without the KERNELDIR argument, dkms wouldn't be able to to build the module for a newly installed kernel.