### PR TITLE
Fix compatibility with kernel 7.0

### DIFF
--- a/src/r8152.c
+++ b/src/r8152.c
@@ -17,6 +17,7 @@
 #include <linux/etherdevice.h>
 #include <linux/mii.h>
 #include <linux/ethtool.h>
+#include <linux/hex.h>
 #include <linux/phy.h>
 #include <linux/usb.h>
 #include <linux/crc32.h>


### PR DESCRIPTION
hex.h is no longer included as part of kernel.h (see torvalds/linux@24c7763)

Fixes #37.